### PR TITLE
Fix hex colors order and tests

### DIFF
--- a/src/lexer.xrl
+++ b/src/lexer.xrl
@@ -2,7 +2,7 @@ Definitions.
 
 INT         = [0-9]+
 FLOAT       = [0-9\.]+
-HEXADECIMAL = #[0-9A-Fa-f]{3,6}
+HEXCOLOR    = #[0-9A-Fa-f]+
 STRING      = [a-zA-Z_\-]+
 EOF         = [\r$]
 WHITESPACE  = [\s\t\n]
@@ -12,7 +12,6 @@ FUNCTION    = (.*)\((.*)\)
 
 Rules.
 {WHITESPACE}+ : skip_token.
-{HEXADECIMAL} : {token, {hex_token, TokenLine, TokenChars}}.
 {COMMENTARY}  : {token, {commentary_token, TokenLine, TokenChars}}.
 {FUNCTION}    : {token, {function_token, TokenLine, TokenChars}}.
 {URL}         : {token, {url_token, TokenLine, TokenChars}}.
@@ -30,6 +29,7 @@ Rules.
 \,            : {token, {comma_token,  TokenLine, TokenChars}}.
 \;            : {token, {semicolon_token,  TokenLine, TokenChars}}.
 \:            : {token, {colon_token,  TokenLine, TokenChars}}.
+{HEXCOLOR}    : {token, {hex_token, TokenLine, TokenChars}}.
 \.            : {token, {dot_token,  TokenLine, TokenChars}}.
 \>            : {token, {major_token,  TokenLine, TokenChars}}.
 \+            : {token, {plus_token,  TokenLine, TokenChars}}.

--- a/test/stylexer/tokenizer_test.exs
+++ b/test/stylexer/tokenizer_test.exs
@@ -13,17 +13,9 @@ defmodule Stylexer.TokenizerTest do
     end
 
     test "hex digits should be parsed" do
-      assert {:ok, [
-        {:hash_token, 1, '#'},
-        {:escaped_token, 1, 'bbaa'},
-        {:digit_token, 1, '13'}
-      ]} === Tokenizer.consume("#bbaa13")
+      assert {:ok, [{:hex_token, 1, '#bbaa13'}]} === Tokenizer.consume("#bbaa13")
 
-      assert {:ok, [
-        {:hash_token, 1, '#'},
-        {:escaped_token, 1, 'Bbaa'},
-        {:digit_token, 1, '13'}
-      ]} === Tokenizer.consume("#Bbaa13")
+      assert {:ok, [{:hex_token, 1, '#Bbaa13'}]} === Tokenizer.consume("#Bbaa13")
     end
 
     test "multline commentaries should be parsed" do
@@ -55,9 +47,7 @@ defmodule Stylexer.TokenizerTest do
         {:left_curly_token, 1, '{'},
         {:escaped_token, 2, 'background'},
         {:colon_token, 2, ':'},
-        {:hash_token, 2, '#'},
-        {:escaped_token, 2, 'ffaa'},
-        {:digit_token, 2, '12'},
+        {:hex_token, 2, '#ffaa12'},
         {:semicolon_token, 2, ';'},
         {:right_curly_token, 3, '}'}
       ]} === Tokenizer.consume(css)
@@ -71,9 +61,7 @@ defmodule Stylexer.TokenizerTest do
         {:left_curly_token, 1, '{'},
         {:escaped_token, 1, 'background'},
         {:colon_token, 1, ':'},
-        {:hash_token, 1, '#'},
-        {:escaped_token, 1, 'ffaa'},
-        {:digit_token, 1, '12'},
+        {:hex_token, 1, '#ffaa12'},
         {:semicolon_token, 1, ';'},
         {:right_curly_token, 1, '}'}
       ]} === Tokenizer.consume(css)


### PR DESCRIPTION
Turns out ordering matters! I was doing some tests with your code and stumbled on the solution for the colors.

Sorry for screwing up the beauty of `lexer.xrl`, I had to move things around! Let me know if you want me to rework it to look better.